### PR TITLE
Clean up static v. page logic

### DIFF
--- a/src/http/errors.rs
+++ b/src/http/errors.rs
@@ -19,6 +19,13 @@ pub enum WebError {
         /// The request path.
         req_path: String,
     },
+
+    /// Permission denied error.
+    #[error("access to {req_path} forbidden")]
+    Forbidden {
+        /// The request path.
+        req_path: String,
+    },
 }
 
 /// `Result` type for `WebError`.
@@ -41,6 +48,11 @@ impl WebError {
             Self::NotFound { req_path } => (
                 http::StatusCode::NOT_FOUND,
                 "error404",
+                mustache_key_value("req_path", req_path),
+            ),
+            Self::Forbidden { req_path } => (
+                http::StatusCode::FORBIDDEN,
+                "error403",
                 mustache_key_value("req_path", req_path),
             ),
         };

--- a/src/http/errors.rs
+++ b/src/http/errors.rs
@@ -1,35 +1,47 @@
 //! Render error pages.
 
+use crate::errors::Error;
 use crate::templates::TemplateManager;
 use actix_web::{HttpRequest, HttpResponse, HttpResponseBuilder, http};
 use htmlize::escape_text;
+use std::io::{self, ErrorKind};
 use std::result::Result;
-use thiserror::Error;
+
+/// `Result` type for `WebError`.
+pub type WebResult<T, E = WebError> = Result<T, E>;
 
 /// An error that will be reported to the user as a web page.
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum WebError {
     /// Internal server error.
     #[error("internal server error: {0}")]
     Internal(#[from] crate::errors::Error),
 
+    /// Internal server error.
+    ///
+    /// This takes a string message for rare conditions.
+    #[error("{0}")]
+    InternalString(String),
+
     /// Page not found error.
-    #[error("page {req_path} not found")]
-    NotFound {
-        /// The request path.
-        req_path: String,
-    },
+    #[error("page not found")]
+    NotFound,
 
     /// Permission denied error.
-    #[error("access to {req_path} forbidden")]
-    Forbidden {
-        /// The request path.
-        req_path: String,
-    },
+    #[error("access forbidden")]
+    Forbidden,
 }
 
-/// `Result` type for `WebError`.
-pub type WebResult<T, E = WebError> = Result<T, E>;
+impl From<io::Error> for WebError {
+    fn from(error: io::Error) -> Self {
+        match error.kind() {
+            // `IsADirectory` is equivalent to `NotFound` for easy fallbacks.
+            ErrorKind::IsADirectory | ErrorKind::NotFound => Self::NotFound,
+            ErrorKind::PermissionDenied => Self::Forbidden,
+            _ => Self::Internal(Error::Io(error)),
+        }
+    }
+}
 
 impl WebError {
     /// Render the error into an `HttpResponse`.
@@ -45,15 +57,20 @@ impl WebError {
                 "error500",
                 mustache_key_value("error", error),
             ),
-            Self::NotFound { req_path } => (
+            Self::InternalString(error) => (
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                "error500",
+                mustache_key_value("error", error),
+            ),
+            Self::NotFound => (
                 http::StatusCode::NOT_FOUND,
                 "error404",
-                mustache_key_value("req_path", req_path),
+                mustache_key_value("req_path", req.path()),
             ),
-            Self::Forbidden { req_path } => (
+            Self::Forbidden => (
                 http::StatusCode::FORBIDDEN,
                 "error403",
-                mustache_key_value("req_path", req_path),
+                mustache_key_value("req_path", req.path()),
             ),
         };
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -10,7 +10,8 @@ use actix_files::NamedFile;
 use actix_web::{
     self, App, HttpRequest, HttpResponse, HttpServer, Responder, get, web::Data,
 };
-use std::ffi::OsStr;
+use std::fs;
+use std::io::{self, Read, Seek};
 use std::path::{Path, PathBuf};
 use tracing;
 use tracing_actix_web::TracingLogger;
@@ -55,51 +56,35 @@ async fn path_handler(
     req: HttpRequest,
     tpls: Data<TemplateManager>,
 ) -> impl Responder {
-    if let Some(path) = find_static_path(req.path()) {
-        render_static(&req, &path)
-    } else {
-        render_page(&req, &tpls)
-    }
-    .unwrap_or_else(|web_error| web_error.render(&req, &tpls))
+    clean_path(req.path())
+        .and_then(|path| match render_static(&req, path) {
+            Err(WebError::NotFound) => {
+                tracing::trace!("static not found, trying page");
+                render_page(&req, path, &tpls)
+            }
+            other => other,
+        })
+        .unwrap_or_else(|error: WebError| error.render(&req, &tpls))
 }
 
-/// Check if a request path corresponds to a static file
-///
-/// Returns `None` if there is no matching static file.
+/// Get a relative path that can be joined to another path safely.
 ///
 /// # Errors
 ///
-/// This should never encounter an error since Actix should clean up the path
-/// for us. If this does encounter an error, e.g. a path containing “..”, it
-/// will log the error to stderr (FIXME) and return `None`.
-fn find_static_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
+///   * [`WebError::InternalString`] if the path doesn’t start with / or if the
+///     path contains a .. segment.
+fn clean_path(path: &str) -> WebResult<&str> {
     // TODO? Actix seems to do deal with .. and maybe // for us. Simplify?
-    let path = path.as_ref();
-    let Ok(path) = path.strip_prefix("/") else {
-        // WTF. It should always start with "/".
-        tracing::error!("reqest path {path:?} does not start with /");
-        return None;
-    };
-
-    // Should be impossible.
-    assert!(
-        !(path.is_absolute() || path.has_root()),
-        "stripped request path {path:?} is not relative"
-    );
-
-    let dotdot = OsStr::new("..");
-    if path.iter().any(|v| v == dotdot) {
-        tracing::error!("stripped request path {path:?} contains ..");
-        return None;
-    }
-
-    let mut static_path = PathBuf::from("static");
-    static_path.push(path);
-
-    if static_path.is_file() {
-        Some(static_path)
+    if !path.starts_with('/') {
+        Err(WebError::InternalString(format!(
+            "reqest path {path:?} does not start with /"
+        )))
+    } else if path.split('/').any(|v| v == "..") {
+        Err(WebError::InternalString(format!(
+            "stripped request path {path:?} contains .."
+        )))
     } else {
-        None
+        Ok(path.trim_start_matches('/'))
     }
 }
 
@@ -109,14 +94,31 @@ fn find_static_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
 ///
 /// This returns <code>[WebError::Internal][]([Error::Io][])</code> if there is
 /// a problem reading the static file.
-fn render_static(req: &HttpRequest, path: &Path) -> WebResult<HttpResponse> {
-    match NamedFile::open(path) {
-        Ok(file) => Ok(file.into_response(req)),
-        Err(error) => {
-            tracing::warn!("failed to open static file {path:?}: {error:?}");
-            Err(WebError::Internal(Error::Io(error)))
-        }
-    }
+fn render_static(
+    req: &HttpRequest,
+    relative_path: &str,
+) -> WebResult<HttpResponse> {
+    Ok(open_static(&PathBuf::from("static").join(relative_path))?
+        .into_response(req))
+}
+
+/// Open a path as a [`NamedFile`].
+///
+/// This reads one byte from the file to check if it’s actually a directory.
+///
+/// # Errors
+///
+///   * [`io::Error`] if there was a problem opening or reading the file.
+fn open_static(path: &Path) -> io::Result<NamedFile> {
+    let mut file = fs::File::open(path)?;
+
+    // Read 1 byte to check if the file is a directory. Using `is_dir()` would
+    // create a race condition.
+    let mut buffer: [u8; 1] = [0];
+    _ = file.read(&mut buffer)?;
+    file.rewind()?;
+
+    NamedFile::from_file(file, path)
 }
 
 /// Render a page to be served over HTTP.
@@ -125,37 +127,39 @@ fn render_static(req: &HttpRequest, path: &Path) -> WebResult<HttpResponse> {
 ///
 /// Returns [`WebError`] if the page cannot be found or cannot be rendered.
 fn render_page(
-    req: &HttpRequest,
+    _req: &HttpRequest,
+    relative_path: &str,
     tpls: &TemplateManager,
 ) -> WebResult<HttpResponse> {
-    let path = find_page_path(req.path())?;
-    let buffer = Page::read_from(&path)?.render_to_string(tpls)?;
+    let root = PathBuf::from("pages");
+    let relative_path = relative_path.trim_end_matches('/');
+
+    let page = try_read_page(root.join(format!("{relative_path}.md")))
+        .or_else(|| try_read_page(root.join(relative_path).join("index.md")))
+        .unwrap_or(Err(WebError::NotFound))?;
 
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=UTF-8")
-        .body(buffer))
+        .body(page.render_to_string(tpls)?))
 }
 
-/// Find the page file that corresponds to a request path.
+/// Read a page file, or return `None` if it doesn’t exist or is a directory.
 ///
 /// # Errors
 ///
-/// Returns [`WebError::NotFound`] if the page cannot be found.
-fn find_page_path(req_path: &str) -> WebResult<PathBuf> {
-    // Actix mostly cleans the path for us (FIXME it should redirect).
-
-    // req_path always starts with a /
-    let base = format!("pages{}", req_path.trim_end_matches('/'));
-
-    let test = PathBuf::from(format!("{base}.md"));
-    if test.is_file() {
-        return Ok(test);
+///   * [`WebError`] if the page cannot be read.
+fn try_read_page(path: PathBuf) -> Option<WebResult<Page>> {
+    match fs::read_to_string(&path) {
+        Ok(content) => match Page::from_string(content) {
+            Ok(mut page) => {
+                page.file = path;
+                Some(Ok(page))
+            }
+            Err(error) => Some(Err(WebError::Internal(error))),
+        },
+        Err(error) => match WebError::from(error) {
+            WebError::NotFound => None,
+            error => Some(Err(error)),
+        },
     }
-
-    let test = PathBuf::from(base).join("index.md");
-    if test.is_file() {
-        return Ok(test);
-    }
-
-    Err(WebError::NotFound { req_path: req_path.to_owned() })
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -50,8 +50,8 @@ impl Page {
     /// # Errors
     ///
     /// This will return [`Error`] if there is a problem parsing `raw`.
-    pub fn from_string(raw: &str) -> Result<Self> {
-        let (header, body) = Self::split_raw_page(raw);
+    pub fn from_string<S: AsRef<str>>(raw: S) -> Result<Self> {
+        let (header, body) = Self::split_raw_page(raw.as_ref());
 
         let mut metadata = Self::metadata_from_string(header)?;
         let fragment = Document::fragment(Self::render_markdown(body));

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -60,6 +60,14 @@ impl TemplateManager {
             .unwrap();
         }
 
+        if !self.has("error403") {
+            self.load_from_string(
+                "error403",
+                include_str!("templates/error403.tmpl"),
+            )
+            .unwrap();
+        }
+
         if !self.has("error404") {
             self.load_from_string(
                 "error404",

--- a/src/templates/error403.tmpl
+++ b/src/templates/error403.tmpl
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Forbidden: {{ req_path }}</title>
+	</head>
+	<body>
+		<h1>Forbidden: {{ req_path }}</h1>
+	</body>
+</html>


### PR DESCRIPTION
- **Add `WebError:Forbidden` and `error403` template.**
  

- **Make static v. page logic more robust**
  Previously this checked if a file existed and then read it to serve a
  static file or a page. This switches to just reading the file and
  dealing with the error, which prevents a race condition where the file
  is deleted before it can be read.
  
  This also cleans up the path cleaning logic, though it’s unclear to me
  whether it’s necessary.
  