### PR TITLE
Lints: allow `Debug` formatting for `Path`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ let_underscore_untyped = "allow"
 manual_string_new = "allow"
 map_unwrap_or = "allow"
 module_name_repetitions = "allow"
-unnecessary_debug_formatting = "allow" # Debug escapes invalid characters, unlike display()
+unnecessary_debug_formatting = "allow" # display() doesn’t escape invalid chars
 
 # Nursery exceptions
 option_if_let_else = "allow"


### PR DESCRIPTION
`Debug` escapes invalid characters and adds quotes, which is often what I want.

(This just updates the comment to match my template.)
