### PR TITLE
Treat paths with non-directory parents as `NotFound`

### DIFF
--- a/src/http/errors.rs
+++ b/src/http/errors.rs
@@ -25,6 +25,9 @@ pub enum WebError {
     InternalString(String),
 
     /// Page not found error.
+    ///
+    /// This generally means that the request will fall through to the next
+    /// layer, e.g. if it was looking for a static file it will look for a page.
     #[error("page not found")]
     NotFound,
 
@@ -34,10 +37,16 @@ pub enum WebError {
 }
 
 impl From<io::Error> for WebError {
+    /// Convert [`io::Error`] into [`WebError`]. Handles fall-through logic.
+    ///
+    /// See [`WebError::NotFound`].
     fn from(error: io::Error) -> Self {
         match error.kind() {
-            // `IsADirectory` is equivalent to `NotFound` for easy fallbacks.
-            ErrorKind::IsADirectory | ErrorKind::NotFound => Self::NotFound,
+            // These errors all map to `NotFound` for the purpose of falling
+            // through to the next possible match.
+            ErrorKind::IsADirectory
+            | ErrorKind::NotFound
+            | ErrorKind::NotADirectory => Self::NotFound,
             ErrorKind::PermissionDenied => Self::Forbidden,
             _ => Self::Internal(Error::Io(error)),
         }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -322,6 +322,32 @@ mod tests {
 
     #[actix_web::test]
     #[traced_test]
+    async fn test_fall_through() {
+        let (_dir, config, app) = init_app().await;
+
+        fs::write(config.static_path.join("static"), "STATIC").unwrap();
+        fs::create_dir(config.pages_path.join("static")).unwrap();
+        fs::write(config.pages_path.join("static/page.md"), "PAGE").unwrap();
+
+        // FIXME check content-type
+        let resp = get(&app, "/static").await;
+        check!(resp.status().as_u16() == 200);
+        let_assert!(Ok(body) = body::to_bytes(resp.into_body()).await);
+        check!(body == B(b"STATIC"));
+
+        let resp = get(&app, "/static/page").await;
+        check!(resp.status().as_u16() == 200);
+        let_assert!(Ok(body) = body::to_bytes(resp.into_body()).await);
+        check!(body == B(b"<p>PAGE</p>\n"));
+
+        let resp = get(&app, "/static/page/.").await;
+        check!(resp.status().as_u16() == 200);
+        let_assert!(Ok(body) = body::to_bytes(resp.into_body()).await);
+        check!(body == B(b"<p>PAGE</p>\n"));
+    }
+
+    #[actix_web::test]
+    #[traced_test]
     async fn test_static_index_get() {
         let (_dir, config, app) = init_app().await;
 


### PR DESCRIPTION
For example, if `/a` is a file, then `/a/b` will generate a
`WebError::NotFound` error rather than `WebError::Internal` wrapping an
`io::Error` with `ErrorKind::NotADirectory`.
