### PR TITLE
Improvements to `render` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log 0.4.27",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1485,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1687,7 @@ dependencies = [
  "clap",
  "dom_query",
  "htmlize",
+ "jiff",
  "mime",
  "mustache",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 dom_query = "0.21.0"
 htmlize = "1.0.6"
+jiff = { version = "0.2.15", features = ["serde"] }
 mustache = "0.9.0"
 pulldown-cmark = "0.13.0"
 regex = "1.11.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,9 @@ pub enum Error {
         /// The original error.
         source: mustache::Error,
         /// The source of the page.
-        page_source: Source,
+        ///
+        /// Boxed to prevent the error type from getting too big.
+        page_source: Box<Source>,
         /// The template name.
         template: String,
     },

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4,7 +4,7 @@ mod errors;
 pub use crate::http::errors::*;
 
 use crate::errors::{Error, Result};
-use crate::render::Page;
+use crate::render::{Page, Source};
 use crate::templates::TemplateManager;
 use actix_files::NamedFile;
 use actix_web::{
@@ -206,9 +206,10 @@ fn render_page(
 ///   * [`WebError`] if the page cannot be read.
 fn try_read_page(path: PathBuf) -> Option<WebResult<Page>> {
     match fs::read_to_string(&path) {
-        Ok(content) => {
-            Some(Page::from_source(path, content).map_err(WebError::Internal))
-        }
+        Ok(content) => Some(
+            Page::from_source(Source::from_path(path), content)
+                .map_err(WebError::Internal),
+        ),
         Err(error) => match WebError::from(error) {
             WebError::NotFound => None,
             error => Some(Err(error)),

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,6 +3,7 @@
 use crate::errors::{Error, Result};
 use crate::templates::TemplateManager;
 use dom_query::Document;
+use jiff::Timestamp;
 use pulldown_cmark::{Options, Parser};
 use regex::Regex;
 use serde::Serialize;
@@ -27,12 +28,52 @@ pub enum Source {
     Stdin,
 
     /// From a file.
-    File(PathBuf),
+    File {
+        /// Path to the file.
+        path: PathBuf,
+
+        /// Time the file was last modified
+        modified: Option<Timestamp>,
+
+        /// Time the file was created
+        created: Option<Timestamp>,
+    },
 }
 
-impl<P: Into<PathBuf>> From<P> for Source {
-    fn from(path: P) -> Self {
-        Self::File(path.into())
+impl Source {
+    /// Create a [`Source::File`] from a `Path`-like object.
+    pub fn from_path<P: Into<PathBuf>>(path: P) -> Self {
+        let path = path.into();
+        let metadata = path.metadata().ok();
+        Self::File {
+            path,
+            modified: metadata
+                .as_ref()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| Timestamp::try_from(t).ok()),
+            created: metadata
+                .as_ref()
+                .and_then(|m| m.created().ok())
+                .and_then(|t| Timestamp::try_from(t).ok()),
+        }
+    }
+
+    /// Get the last modified time, if available.
+    #[must_use]
+    pub const fn modified(&self) -> Option<Timestamp> {
+        match self {
+            Self::File { modified, .. } => *modified,
+            _ => None,
+        }
+    }
+
+    /// Get the creation time, if available.
+    #[must_use]
+    pub const fn created(&self) -> Option<Timestamp> {
+        match self {
+            Self::File { created, .. } => *created,
+            _ => None,
+        }
     }
 }
 
@@ -61,7 +102,7 @@ impl Page {
         let raw = fs::read_to_string(&path)
             .map_err(|error| Error::ReadPageFile { source: error })?;
 
-        Self::from_source(path, &raw)
+        Self::from_source(Source::from_path(path), &raw)
     }
 
     /// Load a `Page` from a string.
@@ -140,7 +181,7 @@ impl Page {
             .render_to_string(&self)
             .map_err(|error| Error::PageRender {
                 source: error,
-                page_source: self.source.clone(),
+                page_source: Box::new(self.source.clone()),
                 template: tpl_name.clone(),
             })
     }


### PR DESCRIPTION
- **`Page`: clarify `render_markdown()` function.**
  

- **`Page`: move utility functions out of `impl`.**
  

- **`Source`: collect creation and modification times for files**
  Presently it’s not possible to use these in a template.
  