### PR TITLE
Redirect to canonical URL for static files

### DIFF
--- a/embed/templates/redirect301.hbs
+++ b/embed/templates/redirect301.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>See {{ canonical_url }}</title>
+	</head>
+	<body>
+		<h1>See <a href="{{ canonical_url }}">{{ canonical_url }}</a></h1>
+	</body>
+</html>

--- a/src/http/errors.rs
+++ b/src/http/errors.rs
@@ -4,6 +4,7 @@ use crate::errors::Error;
 use actix_web::{HttpRequest, HttpResponse, HttpResponseBuilder, http};
 use handlebars::Handlebars;
 use htmlize::escape_text;
+use http::{StatusCode, header};
 use maplit::hashmap;
 use std::io::{self, ErrorKind};
 use std::result::Result;
@@ -34,6 +35,12 @@ pub enum WebError {
     /// Permission denied error.
     #[error("access forbidden")]
     Forbidden,
+
+    /// # Redirect.
+    ///
+    /// Generally this means that a non-canonical URL was requested.
+    #[error("redirect to {0}")]
+    RedirectCanonical(String),
 }
 
 impl From<io::Error> for WebError {
@@ -55,9 +62,9 @@ impl WebError {
     /// Render the error into an `HttpResponse`.
     #[must_use]
     pub fn render(&self, req: &HttpRequest, tpls: &Handlebars) -> HttpResponse {
-        let (code, template_name, data) = match self {
+        let (mut builder, template_name, data) = match self {
             Self::Internal(error) => (
-                http::StatusCode::INTERNAL_SERVER_ERROR,
+                HttpResponseBuilder::new(StatusCode::INTERNAL_SERVER_ERROR),
                 "error500",
                 hashmap! {
                     "error" => error.to_string(),
@@ -66,7 +73,7 @@ impl WebError {
                 },
             ),
             Self::InternalString(error) => (
-                http::StatusCode::INTERNAL_SERVER_ERROR,
+                HttpResponseBuilder::new(StatusCode::INTERNAL_SERVER_ERROR),
                 "error500",
                 hashmap! {
                     "error" => error.clone(),
@@ -75,22 +82,33 @@ impl WebError {
                 },
             ),
             Self::NotFound => (
-                http::StatusCode::NOT_FOUND,
+                HttpResponseBuilder::new(StatusCode::NOT_FOUND),
                 "error404",
                 hashmap! { "req_path" => req.path().to_owned() },
             ),
             Self::Forbidden => (
-                http::StatusCode::FORBIDDEN,
+                HttpResponseBuilder::new(StatusCode::FORBIDDEN),
                 "error403",
                 hashmap! { "req_path" => req.path().to_owned() },
             ),
+            Self::RedirectCanonical(url) => {
+                // FIXME should this be permanent?
+                let mut builder =
+                    HttpResponseBuilder::new(StatusCode::MOVED_PERMANENTLY);
+                builder.insert_header((header::LOCATION, url.clone()));
+                (
+                    builder,
+                    "redirect301",
+                    hashmap! { "canonical_url" => url.clone() },
+                )
+            }
         };
 
         let buffer = tpls
             .render(template_name, &data)
             .unwrap_or_else(|error2| self.fallback_render(req, &error2.into()));
 
-        HttpResponseBuilder::new(code)
+        builder
             .content_type("text/html; charset=UTF-8")
             .body(buffer)
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,4 +1,22 @@
-//! Serve pages over HTTP
+//! # Serve pages over HTTP
+//!
+//! [`path_handler()`][path_handler] first checks if the URL path corresponds to
+//! something in the static directory, then it checks the pages. If nothing is
+//! found it renders the error404 template.
+//!
+//! ## Canonical URLs and redirects
+//!
+//! Riki redirects to the canonical URL of a page when possible.
+//!
+//! The canonical URL will end with a / if (and only if) it corresponds to a
+//! `index.html`-like page or static file.
+//!
+//! | Source path             | Canonical path   |
+//! |-------------------------|------------------|
+//! | `pages/page.md`         | `/page`          |
+//! | `pages/dir/index.md`    | `/dir/`          |
+//! | `static/static.html`    | `/static.html`   |
+//! | `static/dir/index.html` | `/dir/`          |
 
 mod errors;
 pub use crate::http::errors::*;
@@ -12,7 +30,7 @@ use actix_web::{
 };
 use handlebars::Handlebars;
 use std::fs;
-use std::io::{Read, Seek};
+use std::io::{self, Read, Seek};
 use std::path::{Path, PathBuf};
 use tracing;
 use tracing_actix_web::TracingLogger;
@@ -129,10 +147,21 @@ fn clean_path(path: &str) -> WebResult<String> {
             "stripped request path {path:?} contains .."
         )))
     } else {
+        // Remove trailing "index.html".
+        let path = if path.rsplit('/').next() == Some("index.html") {
+            // Any trailing / will be taken care of by the next block of code.
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "the if condition guarantees this is safe"
+            )]
+            &path[..path.len() - "index.html".len()]
+        } else {
+            path
+        };
+
         // This guarantees that the returned path doesn’t start or end with a /,
         // and doesn’t contain any "" or "." segments.
-        // FIXME: redirect (maybe if the canonical path != req.path())?
-        #[expect(clippy::comparison_to_empty)]
+        #[expect(clippy::comparison_to_empty, reason = "clarity")]
         Ok(path
             .split('/')
             .filter(|part| *part != "." && *part != "")
@@ -152,9 +181,10 @@ fn render_static(
     static_path: &Path,
     relative_path: &str,
 ) -> WebResult<HttpResponse> {
-    let candidate = static_path.join(relative_path);
-    Ok(match open_static(&candidate) {
-        Err(WebError::NotFound) => open_static(&candidate.join("index.html")),
+    Ok(match open_static(req, static_path, relative_path) {
+        Err(WebError::NotFound) => {
+            open_static_directory(req, static_path, relative_path)
+        }
         other => other,
     }?
     .into_response(req))
@@ -167,16 +197,49 @@ fn render_static(
 /// # Errors
 ///
 ///   * [`WebError`] if there was a problem opening or reading the file.
-fn open_static(path: &Path) -> WebResult<NamedFile> {
-    let mut file = fs::File::open(path)?;
+fn open_static(
+    req: &HttpRequest,
+    static_path: &Path,
+    relative_path: &str,
+) -> WebResult<NamedFile> {
+    let path = static_path.join(relative_path);
+    let file = open_confirmed_file(&path)?;
 
-    // Read 1 byte to check if the file is a directory. Using `is_dir()` would
-    // create a race condition.
-    let mut buffer: [u8; 1] = [0];
-    _ = file.read(&mut buffer)?;
-    file.rewind()?;
+    // req.path() always starts with /, but relative_path never does
+    if req.path()[1..] == *relative_path {
+        Ok(NamedFile::from_file(file, path)?)
+    } else {
+        Err(WebError::RedirectCanonical(format!("/{relative_path}")))
+    }
+}
 
-    Ok(NamedFile::from_file(file, path)?)
+/// Open a directory path as a [`NamedFile`].
+///
+/// This looks for an `index.html` file inside the directory, then reads one
+/// byte from file to check if it’s actually a directory.
+///
+/// # Errors
+///
+///   * [`WebError`] if there was a problem opening or reading the file.
+fn open_static_directory(
+    req: &HttpRequest,
+    static_path: &Path,
+    relative_path: &str,
+) -> WebResult<NamedFile> {
+    let path = static_path.join(relative_path).join("index.html");
+    let file = open_confirmed_file(&path)?;
+
+    let canonical_path = if relative_path.is_empty() {
+        "/".to_owned()
+    } else {
+        format!("/{relative_path}/")
+    };
+
+    if req.path() == canonical_path {
+        Ok(NamedFile::from_file(file, path)?)
+    } else {
+        Err(WebError::RedirectCanonical(canonical_path))
+    }
 }
 
 /// Render a page to be served over HTTP.
@@ -234,4 +297,23 @@ fn check_dir<P: AsRef<Path>>(path: P) -> Result<()> {
         Err(error) if !is_not_found(&error) => Err(Error::Io(error)),
         _ => Err(Error::MissingDirectory(path.to_path_buf())),
     }
+}
+
+/// Open a file and confirm that it is a file.
+///
+/// This reads one byte to check if the file is a directory (using `is_dir()`
+/// would create a race condition.)
+///
+/// Returns the opened file (rewound).
+///
+/// # Errors
+///
+///   * [`io::Error`] resulting from opening the file, reading a byte, or
+///     seeking to the start of the file.
+fn open_confirmed_file(path: &Path) -> io::Result<fs::File> {
+    let mut file = fs::File::open(path)?;
+    let mut buffer: [u8; 1] = [0];
+    _ = file.read(&mut buffer)?;
+    file.rewind()?;
+    Ok(file)
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -6,7 +6,7 @@ use actix_web::dev::{Service, ServiceResponse};
 use actix_web::http::header::HeaderName;
 use actix_web::test::TestRequest;
 use actix_web::web::{Bytes, Data};
-use actix_web::{App, body, test};
+use actix_web::{App, body, http, test};
 use assert2::check;
 use riki::http::{Configuration, path_handler};
 use std::fs;
@@ -37,6 +37,11 @@ async fn init_app() -> (
     tpls.register_template_string("error404", "404").unwrap();
     tpls.register_template_string("error500", "{{{ error_debug }}}")
         .unwrap();
+    tpls.register_template_string(
+        "redirect301",
+        "redirect {{ canonical_url }}",
+    )
+    .unwrap();
 
     (
         temp_dir,
@@ -80,14 +85,81 @@ fn get_content_type(resp: &ServiceResponse<BoxBody>) -> Option<mime::Mime> {
 /// Convert byte string to right type for comparison with a response body.
 const B: fn(&'static [u8]) -> Bytes = Bytes::from_static;
 
+/// A summarized response that can be compared for easy assertions.
+#[derive(Debug, Eq, PartialEq)]
+struct Response {
+    status: http::StatusCode,
+    content_type: Option<mime::Mime>,
+    last_modified: bool,
+    etag: bool,
+    body: Bytes,
+}
+
+impl Response {
+    /// Create the summary from an actual [`ServiceResponse`].
+    #[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+    async fn from(resp: ServiceResponse<BoxBody>) -> Self {
+        Self {
+            status: resp.status(),
+            content_type: get_content_type(&resp),
+            last_modified: get_header(&resp, header::LAST_MODIFIED).is_some(),
+            etag: get_header(&resp, header::ETAG).is_some(),
+            body: get_body(resp).await,
+        }
+    }
+
+    /// An expected 301 Moved Permanently response.
+    fn redirect(to: &str) -> Self {
+        // FIXME add Location header
+        Self {
+            status: http::StatusCode::MOVED_PERMANENTLY,
+            content_type: Some(mime::TEXT_HTML_UTF_8),
+            last_modified: false,
+            etag: false,
+            body: format!("redirect {to}").into(),
+        }
+    }
+
+    /// An expected response for an HTML page.
+    fn page_html(body: &str) -> Self {
+        Self {
+            status: http::StatusCode::OK,
+            content_type: Some(mime::TEXT_HTML_UTF_8),
+            last_modified: false,
+            etag: false,
+            body: body.to_owned().into(),
+        }
+    }
+
+    /// An expected response for static HTML file.
+    fn static_html(body: &str) -> Self {
+        Self::static_other(body, mime::TEXT_HTML_UTF_8)
+    }
+
+    /// An expected response for static file of `content_type`.
+    fn static_other(body: &str, content_type: mime::Mime) -> Self {
+        Self {
+            status: http::StatusCode::OK,
+            content_type: Some(content_type),
+            last_modified: true,
+            etag: true,
+            body: body.to_owned().into(),
+        }
+    }
+}
+
 /// Make a GET request to the test app.
 #[expect(clippy::future_not_send)] // Actix doesn’t require Send.
-async fn get<S, B, E>(app: S, uri: &str) -> S::Response
+async fn get<S, E>(app: S, uri: &str) -> Response
 where
-    S: Service<Request, Response = ServiceResponse<B>, Error = E>,
+    S: Service<Request, Response = ServiceResponse<BoxBody>, Error = E>,
     E: std::fmt::Debug,
 {
-    test::call_service(&app, TestRequest::get().uri(uri).to_request()).await
+    Response::from(
+        test::call_service(&app, TestRequest::get().uri(uri).to_request())
+            .await,
+    )
+    .await
 }
 
 #[actix_web::test]
@@ -97,19 +169,8 @@ async fn test_index_page_get() {
 
     fs::write(config.pages_path.join("index.md"), "index").unwrap();
 
-    let resp = get(&app, "/").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED) == None);
-    check!(get_header(&resp, header::ETAG) == None);
-    check!(get_body(resp).await == B(b"<p>index</p>\n"));
-
-    let resp = get(&app, "/.").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED) == None);
-    check!(get_header(&resp, header::ETAG) == None);
-    check!(get_body(resp).await == B(b"<p>index</p>\n"));
+    check!(Response::page_html("<p>index</p>\n") == get(&app, "/").await);
+    check!(Response::page_html("<p>index</p>\n") == get(&app, "/.").await);
 }
 
 #[actix_web::test]
@@ -119,26 +180,12 @@ async fn test_static_get() {
 
     fs::write(config.static_path.join("a.txt"), "AAA").unwrap();
 
-    let resp = get(&app, "/a.txt").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_PLAIN_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED).is_some());
-    check!(get_header(&resp, header::ETAG).is_some());
-    check!(get_body(resp).await == B(b"AAA"));
-
-    let resp = get(&app, "/a.txt/").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_PLAIN_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED).is_some());
-    check!(get_header(&resp, header::ETAG).is_some());
-    check!(get_body(resp).await == B(b"AAA"));
-
-    let resp = get(&app, "/a.txt/.").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_PLAIN_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED).is_some());
-    check!(get_header(&resp, header::ETAG).is_some());
-    check!(get_body(resp).await == B(b"AAA"));
+    check!(
+        Response::static_other("AAA", mime::TEXT_PLAIN_UTF_8)
+            == get(&app, "/a.txt").await
+    );
+    check!(Response::redirect("/a.txt") == get(&app, "/a.txt/").await);
+    check!(Response::redirect("/a.txt") == get(&app, "/a.txt/.").await);
 }
 
 #[actix_web::test]
@@ -150,19 +197,9 @@ async fn test_static_index_get() {
     fs::create_dir(b_dir).unwrap();
     fs::write(config.static_path.join("b/index.html"), "BBB").unwrap();
 
-    let resp = get(&app, "/b").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED).is_some());
-    check!(get_header(&resp, header::ETAG).is_some());
-    check!(get_body(resp).await == B(b"BBB"));
-
-    let resp = get(&app, "/b/").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED).is_some());
-    check!(get_header(&resp, header::ETAG).is_some());
-    check!(get_body(resp).await == B(b"BBB"));
+    check!(Response::static_html("BBB") == get(&app, "/b/").await);
+    check!(Response::redirect("/b/") == get(&app, "/b").await);
+    check!(Response::redirect("/b/") == get(&app, "/b/index.html").await);
 }
 
 #[actix_web::test]
@@ -174,20 +211,18 @@ async fn test_fall_through() {
     fs::create_dir(config.pages_path.join("static")).unwrap();
     fs::write(config.pages_path.join("static/page.md"), "PAGE").unwrap();
 
-    let resp = get(&app, "/static").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::APPLICATION_OCTET_STREAM));
-    check!(get_body(resp).await == B(b"STATIC"));
-
-    let resp = get(&app, "/static/page").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_body(resp).await == B(b"<p>PAGE</p>\n"));
-
-    let resp = get(&app, "/static/page/.").await;
-    check!(resp.status().as_u16() == 200);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_body(resp).await == B(b"<p>PAGE</p>\n"));
+    check!(
+        Response::static_other("STATIC", mime::APPLICATION_OCTET_STREAM)
+            == get(&app, "/static").await
+    );
+    check!(Response::redirect("/static") == get(&app, "/static/").await);
+    check!(
+        Response::page_html("<p>PAGE</p>\n") == get(&app, "/static/page").await
+    );
+    check!(
+        Response::page_html("<p>PAGE</p>\n")
+            == get(&app, "/static/page/").await
+    );
 }
 
 #[actix_web::test]
@@ -195,12 +230,15 @@ async fn test_fall_through() {
 async fn test_not_found_get() {
     let (_dir, _config, app) = init_app().await;
 
-    let resp = get(&app, "/not-found").await;
-    check!(resp.status().as_u16() == 404);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED) == None);
-    check!(get_header(&resp, header::ETAG) == None);
-    check!(get_body(resp).await == B(b"404"));
+    let received = get(&app, "/not-found").await;
+    let expected = Response {
+        status: http::StatusCode::NOT_FOUND,
+        content_type: Some(mime::TEXT_HTML_UTF_8),
+        last_modified: false,
+        etag: false,
+        body: B(b"404"),
+    };
+    check!(expected == received);
 }
 
 #[cfg(all(not(target_os = "hermit"), unix))]
@@ -215,12 +253,15 @@ async fn test_forbidden_page_get() {
     fs::write(&path, "forbidden").unwrap();
     fs::set_permissions(&path, fs::Permissions::from_mode(0o200)).unwrap();
 
-    let resp = get(&app, "/forbidden").await;
-    check!(resp.status().as_u16() == 403);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED) == None);
-    check!(get_header(&resp, header::ETAG) == None);
-    check!(get_body(resp).await == B(b"403"));
+    let received = get(&app, "/forbidden").await;
+    let expected = Response {
+        status: http::StatusCode::FORBIDDEN,
+        content_type: Some(mime::TEXT_HTML_UTF_8),
+        last_modified: false,
+        etag: false,
+        body: B(b"403"),
+    };
+    check!(expected == received);
 }
 
 #[cfg(all(not(target_os = "hermit"), unix))]
@@ -235,10 +276,13 @@ async fn test_forbidden_static_get() {
     fs::write(&path, "forbidden").unwrap();
     fs::set_permissions(&path, fs::Permissions::from_mode(0o200)).unwrap();
 
-    let resp = get(&app, "/forbidden.txt").await;
-    check!(resp.status().as_u16() == 403);
-    check!(get_content_type(&resp) == Some(mime::TEXT_HTML_UTF_8));
-    check!(get_header(&resp, header::LAST_MODIFIED) == None);
-    check!(get_header(&resp, header::ETAG) == None);
-    check!(get_body(resp).await == B(b"403"));
+    let received = get(&app, "/forbidden.txt").await;
+    let expected = Response {
+        status: http::StatusCode::FORBIDDEN,
+        content_type: Some(mime::TEXT_HTML_UTF_8),
+        last_modified: false,
+        etag: false,
+        body: B(b"403"),
+    };
+    check!(expected == received);
 }

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -41,7 +41,14 @@ fn embedded_template() {
     let mut embeded_names: Vec<_> = tpls.get_templates().keys().collect();
     embeded_names.sort();
     check!(
-        embeded_names == vec!["default", "error403", "error404", "error500"]
+        embeded_names
+            == vec![
+                "default",
+                "error403",
+                "error404",
+                "error500",
+                "redirect301"
+            ]
     );
 
     let_assert!(Ok(page) = Page::from_memory("title: page\n---\n# Page"));


### PR DESCRIPTION
If a request is made that maps to a static file but isn’t to the
canonical URL, then Riki will now redirect.

For example, `/index.html` to `/`, or `/a.txt/.` to `/a.txt`.
