### PR TITLE
Miscellaneous

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,10 +25,7 @@ pub enum Error {
 
     /// Failed to render page metadata
     #[error("Failed to render page metadata")]
-    MetadataRender {
-        /// The original error
-        source: serde_yaml::Error,
-    },
+    MetadataRender(serde_yaml::Error),
 
     /// An important directory is missing
     #[error("Missing directory {0:?}")]
@@ -53,10 +50,7 @@ pub enum Error {
 
     /// Failed to read page file
     #[error("Failed to read page file")]
-    ReadPageFile {
-        /// The original error.
-        source: io::Error,
-    },
+    ReadPageFile(io::Error),
 
     /// Failed to compile template with [`handlebars`]
     #[error("Failed to compile template at: {0:?}")]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -263,8 +263,7 @@ fn read_page_file(
     clean_path: &str,
 ) -> WebResult<Page> {
     let path = root.join(format!("{}.md", &clean_path[1..]));
-    // FIXME we don’t have to read the whole file if we are going to redirect.
-    let content = fs::read_to_string(&path)?;
+    let mut file = open_confirmed_file(&path)?;
 
     let canonical_path = if clean_path.ends_with("/index") {
         clean_path.strip_suffix("index").unwrap()
@@ -273,6 +272,12 @@ fn read_page_file(
     };
 
     if req.path() == canonical_path {
+        let mut content = String::new();
+        #[expect(
+            clippy::verbose_file_reads,
+            reason = "need to open file before checking path"
+        )]
+        file.read_to_string(&mut content)?;
         Page::from_source(Source::from_path(path), content)
             .map_err(WebError::Internal)
     } else {

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -159,8 +159,7 @@ impl Page {
     /// and
     pub fn read_from<P: Into<PathBuf>>(path: P) -> Result<Self> {
         let path: PathBuf = path.into();
-        let raw = fs::read_to_string(&path)
-            .map_err(|error| Error::ReadPageFile { source: error })?;
+        let raw = fs::read_to_string(&path).map_err(Error::ReadPageFile)?;
 
         Self::from_source(Source::from_path(path), &raw)
     }
@@ -213,7 +212,7 @@ impl Page {
     /// serializing the metadata as YAML.
     pub fn metadata_as_string(&self) -> Result<String> {
         let yaml = serde_yaml::to_string(&self.metadata)
-            .map_err(|source| Error::MetadataRender { source })?;
+            .map_err(Error::MetadataRender)?;
 
         let prefix = "---\n";
         let start = if yaml.starts_with(prefix) {

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -252,11 +252,11 @@ fn split_raw_page(raw: &str) -> (&str, &str) {
     static SPLIT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?:^|\s*[\r\n])---(?:$|[\r\n]\s*)").unwrap()
     });
-    let parts: Vec<&str> = SPLIT_RE.splitn(raw, 2).collect();
-    match parts[..] {
-        [yaml, body] => (yaml, body),
-        [body] => ("", body),
-        _ => unreachable!(),
+    let mut iter = SPLIT_RE.splitn(raw, 2);
+    match (iter.next(), iter.next()) {
+        (Some(yaml), Some(body)) => (yaml, body),
+        (Some(body), None) => ("", body),
+        (None, _) => unreachable!(),
     }
 }
 


### PR DESCRIPTION
- **Use iterator directly rather than calling `collect()` and accessing `Vec`.**
  

- **Simplify a few `Error` variants into tuples instead of single field structs.**
  

- **Don’t read full page before checking the canonical path.**
  