### PR TITLE
Lints: use `#[expect(..., reason = "...")]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ pedantic = { level = "warn", priority = -1 }
 missing_docs_in_private_items = "warn"
 
 # Other restriction lints
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
 arithmetic_side_effects = "warn"
 as_underscore = "warn"
 assertions_on_result_states = "warn"

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -1,5 +1,8 @@
 //! Embedded assets.
-#![expect(clippy::same_name_method)] // triggered by RustEmbed
+#![expect(
+    clippy::same_name_method,
+    reason = "triggered by RustEmbedtriggered by RustEmbed"
+)]
 
 use rust_embed::RustEmbed;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -107,7 +107,7 @@ pub async fn serve<P: AsRef<Path>, S: AsRef<str>>(
 }
 
 /// Handle all GET requests
-#[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+#[expect(clippy::future_not_send, reason = "Actix doesn’t require Send")]
 #[get("/{path:.*}")]
 pub async fn path_handler(
     req: HttpRequest,

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,5 @@
 //! Code to deal with executable parameters.
+#![allow(clippy::allow_attributes, reason = "framework code from a template")]
 
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
@@ -53,7 +54,6 @@ pub enum Command {
 
 impl Params {
     /// Print a warning message in error color to `err_stream()`.
-    #[allow(dead_code)]
     pub fn warn<S: AsRef<str>>(&self, message: S) -> io::Result<()> {
         let mut err_out = self.err_stream();
         err_out.set_color(&error_color())?;
@@ -64,13 +64,12 @@ impl Params {
     }
 
     /// Get stream to use for standard output.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "framework code")]
     pub fn out_stream(&self) -> StandardStream {
         StandardStream::stdout(self.color_choice(&io::stdout()))
     }
 
     /// Get stream to use for errors.
-    #[allow(dead_code)]
     pub fn err_stream(&self) -> StandardStream {
         StandardStream::stderr(self.color_choice(&io::stderr()))
     }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -14,7 +14,7 @@ use temp_dir::TempDir;
 use tracing_test::traced_test;
 
 /// Initialize the test app.
-#[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+#[expect(clippy::future_not_send, reason = "Actix doesn’t require Send")]
 async fn init_app() -> (
     TempDir,
     Configuration,
@@ -57,7 +57,7 @@ async fn init_app() -> (
 }
 
 /// Get body of response
-#[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+#[expect(clippy::future_not_send, reason = "Actix doesn’t require Send")]
 async fn get_body(resp: ServiceResponse<BoxBody>) -> Bytes {
     body::to_bytes(resp.into_body()).await.unwrap()
 }
@@ -97,7 +97,7 @@ struct Response {
 
 impl Response {
     /// Create the summary from an actual [`ServiceResponse`].
-    #[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+    #[expect(clippy::future_not_send, reason = "Actix doesn’t require Send")]
     async fn from(resp: ServiceResponse<BoxBody>) -> Self {
         Self {
             status: resp.status(),
@@ -149,7 +149,7 @@ impl Response {
 }
 
 /// Make a GET request to the test app.
-#[expect(clippy::future_not_send)] // Actix doesn’t require Send.
+#[expect(clippy::future_not_send, reason = "Actix doesn’t require Send")]
 async fn get<S, E>(app: S, uri: &str) -> Response
 where
     S: Service<Request, Response = ServiceResponse<BoxBody>, Error = E>,


### PR DESCRIPTION
This enables two lints:

  * Check for `#[allow(...)]`
  * Check for `#[expect(...)]` without a `reason` (or `allow`).

This fixes all the places where the lint would have triggered.
