### PR TITLE
De-duplicate error messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,13 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     let params = Params::parse();
     cli(&params).unwrap_or_else(|error| {
-        params.warn(format!("Error: {error:#}\n")).unwrap();
+        let error = format!("{error:#}\n");
+        if error.to_lowercase().starts_with("error") {
+            params.warn(error).unwrap();
+        } else {
+            params.warn(format!("Error: {error}")).unwrap();
+        }
+
         ExitCode::FAILURE
     })
 }


### PR DESCRIPTION
When reporting an error that already starts with “error”, don’t output
“Error: ” first.
