### PR TITLE
Better error reporting

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@ use thiserror::Error; // doesn’t conflict with the enum.
 #[derive(Debug, Error)]
 pub enum Error {
     /// Failed to bind to socket
-    #[error("Failed to bind to socket on {address:?}")]
+    #[error("Error binding to socket on {address:?}: {source}")]
     BindError {
         /// The original error
         source: io::Error,
@@ -20,40 +20,45 @@ pub enum Error {
     },
 
     /// IO error
-    #[error("IO error")]
+    #[error("Error in IO: {0}")]
     Io(#[from] io::Error),
 
     /// Failed to render page metadata
-    #[error("Failed to render page metadata")]
+    #[error("Error rendering page metadata: {0}")]
     MetadataRender(serde_yaml::Error),
 
     /// An important directory is missing
     #[error("Missing directory {0:?}")]
     MissingDirectory(PathBuf),
 
-    /// Failed to render page body with [`handlebars`]
-    #[error("Failed to render page body")]
-    PageRender {
+    /// Failed to render page body in a template with [`handlebars`]
+    #[error("{source}")]
+    TemplateRender {
         /// The original error.
         source: handlebars::RenderError,
+
         /// The source of the page.
         ///
         /// Boxed to prevent the error type from getting too big.
         page_source: Box<Source>,
-        /// The template name.
-        template: String,
     },
 
     /// Failed to parse page metadata
-    #[error("Failed to parse page metadata")]
+    #[error("Error parsing page metadata: {0}")]
     ParsePageMetadata(#[from] serde_yaml::Error),
 
     /// Failed to read page file
-    #[error("Failed to read page file")]
-    ReadPageFile(io::Error),
+    #[error("Error reading page file {path:?}: {source}")]
+    ReadPageFile {
+        /// The original error
+        source: io::Error,
+
+        /// The page file
+        path: PathBuf,
+    },
 
     /// Failed to compile template with [`handlebars`]
-    #[error("Failed to compile template at: {0:?}")]
+    #[error(transparent)]
     TemplateCompile(#[from] handlebars::TemplateError),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     let params = Params::parse();
     cli(&params).unwrap_or_else(|error| {
-        let error = format!("{error:#}\n");
+        tracing::debug!("Exiting with error: {error:#?}");
+        let error = format!("{error}\n");
         if error.to_lowercase().starts_with("error") {
             params.warn(error).unwrap();
         } else {

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -155,11 +155,13 @@ impl Page {
     ///
     /// # Errors
     ///
-    /// This will return [`Error`] if there is a problem loading `path`.
-    /// and
+    ///   * [`Error::ReadPageFile`] for problems reading `path`.
+    ///   * [`Error::ParsePageMetadata`] for errors parsing metadata.
     pub fn read_from<P: Into<PathBuf>>(path: P) -> Result<Self> {
         let path: PathBuf = path.into();
-        let raw = fs::read_to_string(&path).map_err(Error::ReadPageFile)?;
+        let raw = fs::read_to_string(&path).map_err(|error| {
+            Error::ReadPageFile { source: error, path: path.clone() }
+        })?;
 
         Self::from_source(Source::from_path(path), &raw)
     }
@@ -168,7 +170,7 @@ impl Page {
     ///
     /// # Errors
     ///
-    /// This will return [`Error`] if there is a problem parsing `raw`.
+    ///   * [`Error::ParsePageMetadata`] for errors parsing metadata.
     pub fn from_memory<S: AsRef<str>>(raw: S) -> Result<Self> {
         Self::from_source(Source::Memory, raw)
     }
@@ -177,7 +179,7 @@ impl Page {
     ///
     /// # Errors
     ///
-    /// This will return [`Error`] if there is a problem parsing `raw`.
+    ///   * [`Error::ParsePageMetadata`] for errors parsing metadata.
     pub fn from_source<R: AsRef<str>>(source: Source, raw: R) -> Result<Self> {
         let (header, body) = split_raw_page(raw.as_ref());
 
@@ -237,12 +239,12 @@ impl Page {
     /// This will return [`Error`] if there is a problem loading the template or
     /// rendering the page.
     pub fn render_to_string(&self, tpls: &Handlebars) -> Result<String> {
-        tpls.render(&self.template, &self)
-            .map_err(|error| Error::PageRender {
+        tpls.render(&self.template, &self).map_err(|error| {
+            Error::TemplateRender {
                 source: error,
                 page_source: Box::new(self.source.clone()),
-                template: self.template.clone(),
-            })
+            }
+        })
     }
 }
 


### PR DESCRIPTION
This updates the error code to avoid duplicating error messages, adds
more the path to page read errors, and outputs `Debug` information about
errors in debug mode (`-vv`).
