### PR TITLE
Ignore unmaintained fxhash crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,8 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2025-0057", # fxhash unmaintained
+]
+
 [graph]
 all-features = true
 


### PR DESCRIPTION
The [fxhash] crate hasn’t been maintained for [6 years], and
[RUSTSEC-2025-0057] was just issued for it.

We depend on it via [dom_query], which depends on [selectors], which is
part of [stylo], which tracks part of the Mozilla codebase. So,
submitting a patch involves a lot more work than just putting in a PR,
even if the fxhash crate is easy to replace with [rustc-hash].

[fxhash]: https://github.com/cbreeden/fxhash
[6 years]: https://github.com/cbreeden/fxhash/issues/20
[RUSTSEC-2025-0057]: https://rustsec.org/advisories/RUSTSEC-2025-0057
[dom_query]: https://github.com/niklak/dom_query
[selectors]: https://github.com/servo/stylo/tree/main/selectors
[stylo]: https://github.com/servo/stylo
[rustc-hash]: https://github.com/rust-lang/rustc-hash
