### PR TITLE
Add `$` helper to handle optional variables

### DIFF
--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -1,7 +1,39 @@
 //! Template helpers
 
-use handlebars::{Handlebars, RenderErrorReason, handlebars_helper};
+use handlebars::{
+    Context, Handlebars, Helper, HelperDef, HelperResult, Output,
+    RenderContext, RenderErrorReason, handlebars_helper,
+};
 use jiff::{Timestamp, tz::TimeZone};
+
+/// `{{$ var}}` — output the value of `var` or nothing if `var` doesn’t exist.
+#[derive(Clone, Copy)]
+pub struct DollarHelper;
+
+impl HelperDef for DollarHelper {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        helper: &Helper<'rc>,
+        _registry: &'reg Handlebars<'reg>,
+        _ctx: &'rc Context,
+        _render_ctx: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let param = helper
+            .param(0)
+            .ok_or(RenderErrorReason::ParamNotFoundForIndex("$", 0))?;
+
+        let value = param.value();
+        if !value.is_null() {
+            out.write(
+                value
+                    .as_str()
+                    .ok_or(RenderErrorReason::InvalidParamType("String"))?,
+            )?;
+        }
+        Ok(())
+    }
+}
 
 // Format [`Timestamp`], e.g. `source.File.modified`.
 handlebars_helper!(strftime:
@@ -18,4 +50,5 @@ handlebars_helper!(strftime:
 /// Register helpers.
 pub fn register(tpls: &mut Handlebars) {
     tpls.register_helper("strftime", Box::new(strftime));
+    tpls.register_helper("$", Box::new(DollarHelper));
 }


### PR DESCRIPTION
Previously, if you wanted to use a variable that might not be set, you
would have to do something like:

    {{#if metadata.body_id}}{{ metadata.body_id }}{{/if}}

This helper makes that simpler:

    {{$ metadata.body_id }}
