### PR TITLE
Handle page source specially

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -126,6 +126,26 @@ pub fn handle_a_email(_ctx: &Context, node: &NodeRef) -> Result<()> {
     Ok(())
 }
 
+/// Handle an `a-email` element when outputting the source.
+///
+/// This just redacts the `href`, if present.
+pub fn handle_a_email_source(node: &NodeRef) {
+    let Some(href) = node.attr("href") else {
+        // Nothing to redact.
+        return;
+    };
+
+    match href.parse::<Url>() {
+        Ok(mut url) => {
+            url.set_path("***@*****");
+            node.set_attr("href", url.as_str());
+        }
+        Err(_) => {
+            node.set_attr("href", "*****");
+        }
+    }
+}
+
 /// Handle a `last-modified` element
 ///
 /// # Errors

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -23,13 +23,14 @@ pub use crate::http::errors::*;
 pub mod util;
 
 use crate::errors::{Error, Result};
-use crate::pages::{Page, Source};
+use crate::pages::{Page, Source, render_source_to_string};
 use crate::templates::templates_from_directory;
 use actix_files::NamedFile;
 use actix_web::{
     self, App, HttpRequest, HttpResponse, HttpServer, Responder, get, web::Data,
 };
 use handlebars::Handlebars;
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use tracing;
@@ -107,12 +108,20 @@ pub async fn path_handler(
     config: Data<Configuration>,
 ) -> impl Responder {
     clean_path(req.path())
-        .and_then(|path| match render_static(&req, &config.root_path, &path) {
-            Err(WebError::NotFound) => {
-                tracing::trace!("static not found, trying page");
-                render_page(&req, &config.root_path, &path, &tpls)
+        .and_then(|path| {
+            match render_page_source(&req, &config.root_path, &path) {
+                Err(WebError::NotFound) => {
+                    tracing::trace!("source not found, trying static");
+                    match render_static(&req, &config.root_path, &path) {
+                        Err(WebError::NotFound) => {
+                            tracing::trace!("static not found, trying page");
+                            render_page(&req, &config.root_path, &path, &tpls)
+                        }
+                        other => other,
+                    }
+                }
+                other => other,
             }
-            other => other,
         })
         .unwrap_or_else(|error: WebError| {
             tracing::error!("{}: {error:?}", req.path());
@@ -240,6 +249,33 @@ fn fix_charset(file: NamedFile) -> WebResult<NamedFile> {
             ))
         })?),
     )
+}
+
+/// Render a page source to be served over HTTP.
+///
+/// # Errors
+///
+///   * [`WebError::NotFound`] if the page cannot be read, or if the path
+///     doesn’t end with `.md`.
+fn render_page_source(
+    _req: &HttpRequest,
+    root: &Path,
+    clean_path: &str,
+) -> WebResult<HttpResponse> {
+    // FIXME do this without allocating
+    if !clean_path.to_lowercase().ends_with(".md") {
+        // FIXME? fall through
+        return Err(WebError::NotFound);
+    }
+
+    let path = root.join(&clean_path[1..]);
+
+    // FIXME: caching headers based on template and Page.
+    // FIXME: add cache-busting to href, src, etc. in HTML.
+
+    Ok(HttpResponse::Ok()
+        .content_type("text/markdown; charset=UTF-8")
+        .body(render_source_to_string(fs::read_to_string(&path)?)))
 }
 
 /// Render a page to be served over HTTP.

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,7 +1,8 @@
 //! Handle rendering a page.
 
 use crate::elements::{
-    self, ElementError, handle_a_email, handle_last_modified,
+    self, ElementError, handle_a_email, handle_a_email_source,
+    handle_last_modified,
 };
 use crate::errors::{Error, Result};
 use actix_web::HttpRequest;
@@ -275,6 +276,24 @@ impl Page {
         }
 
         Ok(document.html().to_string())
+    }
+}
+
+/// Render a page source to a string.
+#[must_use]
+#[expect(clippy::needless_pass_by_value, reason = "ToString accepts borrows")]
+pub fn render_source_to_string<S: ToString>(source: S) -> String {
+    let document = Document::from(source.to_string());
+
+    for node in document.select("a-email").nodes() {
+        handle_a_email_source(node);
+    }
+
+    if let Some(body) = document.body() {
+        body.inner_html().to_string()
+    } else {
+        tracing::warn!("Should be unreachable: no document body element.");
+        String::new()
     }
 }
 

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -3,7 +3,7 @@
 use assert2::{check, let_assert};
 use jiff::Timestamp;
 use regex::Regex;
-use riki::{Page, Result, Source};
+use riki::{Page, Result, Source, render_source_to_string};
 use std::path::PathBuf;
 
 /// Makes error output more legible.
@@ -134,5 +134,52 @@ fn a_email() {
     check!(
         let Ok("<html><head></head><body><p><b>Invalid URL in href attribute on &lt;a-email&gt;</b></p>\n</body></html>")
             = page.render_to_string(&tpls, None).as_ref().map(AS_STR)
+    );
+}
+
+#[test]
+fn a_email_source() {
+    check!(
+        "title: test\n\n---\n\n<b>test</b>\n".to_owned()
+            == render_source_to_string("title: test\n\n---\n\n<b>test</b>\n")
+    );
+
+    check!(
+        r#"<a-email href="mailto:***@*****"></a-email>"#.to_owned()
+            == render_source_to_string(
+                r#"<a-email href="mailto:abc@example.com"></a-email>"#
+            )
+    );
+
+    check!(
+        r#"<a-email href="mailto:***@*****?subject=test"></a-email>"#
+            .to_owned()
+            == render_source_to_string(
+                r#"<a-email href="mailto:abc@example.com?subject=test"></a-email>"#
+            )
+    );
+
+    check!(
+        r#"<a-email href="mailto:***@*****">text</a-email>"#.to_owned()
+            == render_source_to_string(
+                r#"<a-email href="mailto:abc@example.com">text</a-email>"#
+            )
+    );
+
+    check!(
+        r#"<a-email href="*****"></a-email>"#.to_owned()
+            == render_source_to_string(
+                r#"<a-email href="abc@example.com"></a-email>"#
+            )
+    );
+
+    check!(
+        r#"<a-email href="*****"></a-email>"#.to_owned()
+            == render_source_to_string(r#"<a-email href=""></a-email>"#)
+    );
+
+    check!(
+        r"<a-email></a-email>".to_owned()
+            == render_source_to_string(r"<a-email></a-email>")
     );
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -129,17 +129,20 @@ impl Response {
         }
     }
 
+    /// An expected response for a Markdown file (a page source).
+    fn page_source(body: &str) -> Self {
+        Self {
+            status: http::StatusCode::OK,
+            content_type: Some("text/markdown; charset=utf-8".parse().unwrap()),
+            last_modified: false,
+            etag: false,
+            body: body.to_owned().into(),
+        }
+    }
+
     /// An expected response for a static HTML file.
     fn static_html(body: &str) -> Self {
         Self::static_other(body, mime::TEXT_HTML_UTF_8)
-    }
-
-    /// An expected response for a static Markdown file.
-    fn static_markdown(body: &str) -> Self {
-        Self::static_other(
-            body,
-            "text/markdown; charset=utf-8".parse().unwrap(),
-        )
     }
 
     /// An expected response for a static file of type `content_type`.
@@ -184,7 +187,7 @@ async fn test_directory_page_get() {
     );
     check!(Response::redirect("/") == get(&app, "/.").await);
     check!(Response::redirect("/") == get(&app, "/index").await);
-    check!(Response::static_markdown("index") == get(&app, "/index.md").await);
+    check!(Response::page_source("index") == get(&app, "/index.md").await);
 
     check!(
         Response::page_html(
@@ -195,9 +198,7 @@ async fn test_directory_page_get() {
     check!(Response::redirect("/dir/") == get(&app, "/dir/.").await);
     check!(Response::redirect("/dir/") == get(&app, "/dir/index").await);
     check!(Response::redirect("/dir/") == get(&app, "/dir/././index").await);
-    check!(
-        Response::static_markdown("DIR") == get(&app, "/dir/index.md").await
-    );
+    check!(Response::page_source("DIR") == get(&app, "/dir/index.md").await);
 }
 
 #[actix_web::test]
@@ -215,7 +216,7 @@ async fn test_file_page_get() {
     check!(Response::redirect("/page") == get(&app, "/page/").await);
     check!(Response::redirect("/page") == get(&app, "/page/.").await);
     check!(Response::redirect("/page") == get(&app, "/page/././").await);
-    check!(Response::static_markdown("PAGE") == get(&app, "/page.md").await);
+    check!(Response::page_source("PAGE") == get(&app, "/page.md").await);
 }
 
 #[actix_web::test]
@@ -267,9 +268,7 @@ async fn test_static_index_with_page() {
     check!(
         Response::redirect("/static/page") == get(&app, "/static/page/").await
     );
-    check!(
-        Response::static_markdown("PAGE") == get(&app, "/static/page.md").await
-    );
+    check!(Response::page_source("PAGE") == get(&app, "/static/page.md").await);
 }
 
 #[actix_web::test]
@@ -282,7 +281,7 @@ async fn test_static_hides_page() {
 
     check!(Response::static_html("STATIC") == get(&app, "/").await);
     check!(Response::redirect("/") == get(&app, "/index.html").await);
-    check!(Response::static_markdown("PAGE") == get(&app, "/index.md").await);
+    check!(Response::page_source("PAGE") == get(&app, "/index.md").await);
 }
 
 #[actix_web::test]


### PR DESCRIPTION
When serving a Markdown file, assume that it’s the source for a page and
redact the `<a-email>` element.
