### PR TITLE
Security: update anyhow to avoid potential unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/cli/main.rs"
 
 [dependencies]
 ambassador = "0.5.0"
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 axum = "0.8.8"
 base64 = "0.22.1"
 bstr = "1.12.0"


### PR DESCRIPTION
[RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190):

> Affected versions of this crate violate borrow rules, resulting in
> undefined behavior, when the user adds context to an error via
> `Error::context` and then later calls `Error::downcast_mut` on the
> returned `Error`.
