### PR TITLE
Security: update transitive dependency crossbeam-epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
This is only used by benchmarks, so it was a non-issue.

[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204):

> Affected versions of `fmt::Display` dereference the underlying
> pointer. This causes a invalid pointer dereference e.g., when a
> pointer created with `Atomic::null` or `Shared::null`. `fmt::Debug`
> impls and pre-0.9 `fmt::Display` impls, which do not dereference
> pointers, are not affected by this issue.
